### PR TITLE
Fix sysrev-related error handling

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -189,6 +189,7 @@ module.exports = function(options, _sr, _analyzer, _containers) {
       if (err) { out.stdout(err); logger.error(err); return cb(err); }
       if (!containerDefId) { out.stdout(ERR_NOCDEF); logger.error(ERR_NOCDEF); return cb(ERR_NOCDEF); }
       _sr.getHead(systemId, function(err, json) {
+        if (err) { out.stderr(err); logger.error(err); return cb(err); }
         var root = _sys(options);
 
         out.progress('synchronizing repository');

--- a/lib/sysrev/sysrev.js
+++ b/lib/sysrev/sysrev.js
@@ -139,7 +139,7 @@ module.exports = function(options, logger) {
             doc = JSON.parse(doc);
           }
           catch (e) {
-            return cb('invalid system: ' + e);
+            return cb(new Error('invalid system: ' + e.message));
           }
         }
         else {
@@ -163,7 +163,7 @@ module.exports = function(options, logger) {
       });
     }
     else {
-      cb('invalid url');
+      cb(new Error('invalid url: ' + url));
     }
   };
 
@@ -238,13 +238,14 @@ module.exports = function(options, logger) {
     var repoPath = _meta.repoPath(systemId);
     git.getFileRevision(repoPath, revisionId, 'system.json', function(err, rev) {
       if (err) { return cb(err); }
+      var s;
       try {
-        var s = JSON.parse(rev);
-        cb(err, s);
+        s = JSON.parse(rev);
       }
       catch (e) {
-        cb('invalid system definition: ' + e, null);
+        return cb(new Error('invalid system definition: ' + e.message), null);
       }
+      cb(err, s);
     });
   };
 
@@ -337,7 +338,7 @@ module.exports = function(options, logger) {
         cb(err, revision.id);
       }
       else {
-        cb('revision not found');
+        cb(new Error('revision not found'));
       }
     });
   };
@@ -389,7 +390,7 @@ module.exports = function(options, logger) {
         cb(null, containerId);
       }
       else {
-        cb('getHead returned 0 data');
+        cb(new Error('getHead returned 0 data'));
       }
     });
   };


### PR DESCRIPTION
Don't ignore errors from `getHead`.
Don't return strings as errors as they lose stack information.
Don't obscure exceptions occurring in `getRevision` callbacks.
