### PR TITLE
Fixed nsd cont buildall.

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -56,28 +56,34 @@ module.exports = function(config, _containers) {
     var err = 'no matching container available for type: ' + cdef.type;
     var container = _containers[cdef.type];
 
-    out.progress('--> executing container specific build');
-    logger.info('executing container specific build');
     if (!container) { logger.error(err); return cb(err); }
-    container.build(mode, system, cdef, out, function(err, specific) {
-      if (err) { logger.error(err); out.stdout(err); return cb(err); }
 
-      out.progress('--> updating topology');
-      logger.info('updating topology');
+    if (container.build) {
+      out.progress('--> executing container specific build');
+      logger.info('executing container specific build');
+      container.build(mode, system, cdef, out, function(err, specific) {
+        if (err) { logger.error(err); out.stdout(err); return cb(err); }
 
-      var matches = _.filter(system.topology.containers, function(c) {
-        return c.containerDefinitionId === cdef.id;
+        out.progress('--> updating topology');
+        logger.info('updating topology');
+
+        var matches = _.filter(system.topology.containers, function(c) {
+          return c.containerDefinitionId === cdef.id;
+        });
+        _.each(matches, function(ctnr) {
+          ctnr.specific = specific;
+          updateTopology(system, cdef, ctnr);
+        });
+
+        if (cdef.specific.buildHead) {
+          cdef.specific.buildHead = cdef.specific.buildHead + 1;
+        }
+        cb(err, specific);
       });
-      _.each(matches, function(ctnr) {
-        ctnr.specific = specific;
-        updateTopology(system, cdef, ctnr);
-      });
-
-      if (cdef.specific.buildHead) {
-        cdef.specific.buildHead = cdef.specific.buildHead + 1;
-      }
-      cb(err, specific);
-    });
+    } else {
+      out.progress('--> no need to build this container');
+      cb(null, {});
+    }
   };
 
 

--- a/lib/deployer.js
+++ b/lib/deployer.js
@@ -118,6 +118,7 @@ module.exports = function(config, _containers) {
     if (target) {
       logger.info('creating deployment plan');
       var plan = planner(deployed, target);
+      console.log(plan)
       out.plan(plan);
       if (!plan) {
         out.stdout('Unable to plan! -- THIS IS SERIOUS, please report it', 'warn');

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -51,7 +51,7 @@ exports.boot = function(config, cb) {
   }
 
   function validateContainer(containerJson, container, cb) {
-    var required = ['build', 'deploy', 'start', 'stop', 'link', 'unlink', 'undeploy'];
+    var required = ['deploy', 'start', 'stop', 'link', 'unlink', 'undeploy', 'add', 'remove'];
     var err = 'invalid container: ' + containerJson.require + ' ';
     var stat = true;
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "async": "^0.9.0",
     "aws-ami-container": "~0.3.1",
     "aws-elb-container": "~0.3.1",
-    "blank-container": "git+https://github.com/nearform/blank-container.git",
+    "blank-container": "git+https://github.com/nearform/blank-container.git#build-all-fix",
     "bunyan": "^1.0.0",
     "docker-container": "git+https://github.com/nearform/docker-container.git",
     "forever-monitor": "^1.3.0",


### PR DESCRIPTION
Building a blank container was overwriting the initial id (10) locally with a new id.
With this refactor, the blank container is not built.

Depends on https://github.com/nearform/blank-container/pull/3.

@pelger I think also all the aws-*-containers should be updated with the same fix, as they should not be built. What do you think?
