### PR TITLE
Support abbreviated container names

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -143,41 +143,36 @@ module.exports = function(options, _sr, _analyzer, _containers) {
     if (!systemId) {
       logger.error(ERR_NOSYSID); return cb(new Error(ERR_NOSYSID));
     }
-
     var systemRoot = _sr.repoPath(systemId);
     out.initProgress(9, '--> finding container');
 
-    _builder.loadTargets(systemId, revision, function(err, targets) {
-      if (err) { return cb(err); }
-      var tempTargets = {};
+    fetchTarget(systemId, target, revision, function(err, target) {
+      if (err) { return cb(err) }
+        _builder.loadTarget(systemId, revision, target, function(err, targets) {
+        if (err) { return cb(err); }
+        _builder.findContainer(systemId, targets, containerIdentifier, function(err, containerDefId, targets) {
+          if (err) { out.stdout(err); logger.error(err); return cb(err); }
+          if (!containerDefId) { out.stdout(ERR_NOCDEF); logger.error(ERR_NOCDEF); return cb(ERR_NOCDEF); }
 
-      if (target !== 'alltargets') {
-        tempTargets[target] = targets[target];
-        targets = tempTargets;
-      }
+          async.eachSeries(_.values(targets), function(json, cb) {
+            root = _sys(options);
+            root.load(json);
+            containerDef = root.containerDefByDefId(containerDefId);
+            console.log(containerDefId, containerDef);
+            json.repoPath = systemRoot;
 
-      _builder.findContainer(systemId, targets, containerIdentifier, function(err, containerDefId, targets) {
-        if (err) { out.stdout(err); logger.error(err); return cb(err); }
-        if (!containerDefId) { out.stdout(ERR_NOCDEF); logger.error(ERR_NOCDEF); return cb(ERR_NOCDEF); }
+            if (!containerDef.specific || !containerDef.specific.repositoryUrl) {
+              return _builder.build(user, systemId, targets, json, containerDef, target, out, cb);
+            }
 
-        async.eachSeries(_.values(targets), function(json, cb) {
-          root = _sys(options);
-          root.load(json);
-          containerDef = root.containerDefByDefId(containerDefId);
-          console.log(containerDefId, containerDef);
-          json.repoPath = systemRoot;
-
-          if (!containerDef.specific || !containerDef.specific.repositoryUrl) {
-            return _builder.build(user, systemId, targets, json, containerDef, target, out, cb);
-          }
-
-          _synchrotron.synch(json, containerDef, out, function(err) {
-            if (err) { out.stdout(err); logger.error(err); return cb(err); }
-            _builder.build(user, systemId, targets, json, containerDef, target, out, cb);
-          });
-        }, cb)
+            _synchrotron.synch(json, containerDef, out, function(err) {
+              if (err) { out.stdout(err); logger.error(err); return cb(err); }
+              _builder.build(user, systemId, targets, json, containerDef, target, out, cb);
+            });
+          }, cb)
+        });
       });
-    });
+    })
   };
 
 
@@ -193,46 +188,50 @@ module.exports = function(options, _sr, _analyzer, _containers) {
     }
 
     logger.info({ systemId: systemId, revision: revision }, 'building all containers');
-    out.stdout('--> building all containers for ' + systemName + ' revision ' + revision);
+    fetchTarget(systemId, target, revision, function(err, target) {
+      if (err) { return cb(err) }
 
-    _builder.loadTargets(systemId, revision, function(err, targets) {
-      if (err) { return cb(err); }
+        out.stdout('--> building all containers for ' + systemName + ' revision ' + revision + ' target ' + target);
 
-      var containers = _.chain(targets)
-        .filter(function(value, key) {
-          return target === 'alltargets' || key === target;
-        })
-        .map(function(target) {
-          return _.map(target.containerDefinitions, function(cdef) {
-            return {
-              id: cdef.id,
-              target: target.topology.name,
-              type: cdef.type
-            };
+        _builder.loadTarget(systemId, revision, target, function(err, targets) {
+        if (err) { return cb(err); }
+
+        var containers = _.chain(targets)
+          .filter(function(value, key) {
+            return target === 'alltargets' || key === target;
+          })
+          .map(function(target) {
+            return _.map(target.containerDefinitions, function(cdef) {
+              return {
+                id: cdef.id,
+                target: target.topology.name,
+                type: cdef.type
+              };
+            });
+          })
+          .flatten()
+          .reduce(function(acc, cont) {
+            var notPresent = !_.find(acc, function(found) {
+              return found.id === cont.id && found.type === cont.type;
+            });
+            console.log(notPresent, cont);
+
+            if (notPresent) {
+              acc.push(cont);
+            }
+
+            return acc;
+          }, [])
+          .value();
+
+        async.eachSeries(containers, function (cont, next) {
+          buildContainer(user, systemId, cont.id, revision, cont.target, out, function(err) {
+            if (err) { out.stderr(err); }
+            next();
           });
-        })
-        .flatten()
-        .reduce(function(acc, cont) {
-          var notPresent = !_.find(acc, function(found) {
-            return found.id === cont.id && found.type === cont.type;
-          });
-          console.log(notPresent, cont);
-
-          if (notPresent) {
-            acc.push(cont);
-          }
-
-          return acc;
-        }, [])
-        .value();
-
-      async.eachSeries(containers, function (cont, next) {
-        buildContainer(user, systemId, cont.id, revision, cont.target, out, function(err) {
-          if (err) { out.stderr(err); }
-          next();
-        });
-      }, cb);
-    });
+        }, cb);
+      });
+    })
   };
 
 
@@ -240,28 +239,29 @@ module.exports = function(options, _sr, _analyzer, _containers) {
    * Supports target abbreviation
    */
   var fetchTarget = function(systemId, target, revision, cb) {
-
     if (typeof revision === 'function') {
       cb = revision;
       revision = 'latest';
     }
-
-    _builder.loadTargets(systemId, revision, function(err, targets) {
+    if (target === "alltargets") {
+      cb(null, target)
+    }
+    else {
+      _builder.loadTargets(systemId, revision, function(err, targets) {
       if (err) { return cb(err); }
-
-      var candidates = Object.keys(targets).filter(function(candidate) {
+        var candidates = Object.keys(targets).filter(function(candidate) {
         return candidate.indexOf(target) >= 0;
-      });
+        });
 
-      if (candidates.length === 0 || candidates.length > 1) {
-        logger.error(ERR_NOTARGET);
-        return cb(new Error(ERR_NOTARGET));
-      } else {
-        target = candidates[0];
-      }
-
-      cb(null, target);
-    })
+        if (candidates.length === 0 || candidates.length > 1) {
+          logger.error(ERR_NOTARGET);
+          return cb(new Error(ERR_NOTARGET));
+        } else {
+          target = candidates[0];
+        }
+        cb(null, target);
+    });
+    }
   };
 
   /**

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -128,8 +128,28 @@ module.exports = function(config, _containers, _sr, _compiler) {
     });
   };
 
+  var loadTarget = function loadTarget(systemId, revision, target, cb) {
+    if (target === 'alltargets') {
+      loadTargets(systemId, revision, function(err, targets) {
+        if (err) { return targets; }
+          cb(err, targets)
+      })
+    }
+    else {
+      var result = {};
+      var path = _sr.repoPath(systemId);
+
+      _sr.getRevision(systemId, revision, target, function(err, json) {
+        if (err) { return cb(err); }
+          result[target] = json;
+          cb(err, result);
+        })
+    }
+  };
+
   return {
     loadTargets: loadTargets,
+    loadTarget: loadTarget,
     findContainer: findContainer,
     build: build
   };


### PR DESCRIPTION
Building has better support for misspelled target names.

I've added a new function that loads a single target. If it's passed the "alltargets" argument. It returns the result of the loadTargets function instead. This way we never have to touch loadTargets twice.

tested a building, compiling and deploying. Errors will still crop up depending on the order the arguments are supplied on the cli but I will try to refactor the client next