### PR TITLE
Stop nscale gracefully

### DIFF
--- a/bin/nscale-kernel.js
+++ b/bin/nscale-kernel.js
@@ -41,8 +41,10 @@ process.on('exit', function(code) {
   if (fs.existsSync(pidFile)) { fs.unlinkSync(pidFile); }
 });
 
-var signals = ['SIGINT', 'SIGTERM', 'SIGHUP']
+var signals = ['SIGINT', 'SIGTERM', 'SIGHUP'];
 
 signals.forEach(function(signal) {
-  process.on(signal, process.exit);
+  process.on(signal, function() {
+    kernel.stop();
+  });
 });

--- a/lib/containers.js
+++ b/lib/containers.js
@@ -204,15 +204,48 @@ module.exports = function(loadConfig, logger, sr) {
     });
   }
 
+  function toRelease() {
+    var result = [];
+    Object.keys(containers).forEach(function(systemKey) {
+      Object.keys(containers[systemKey]).forEach(function(containerKey) {
+        if (containers[systemKey][containerKey].release) {
+          result.push(containers[systemKey][containerKey]);
+        }
+      });
+    });
+    return result;
+  }
+
+  function toClose() {
+    return _.map(Object.keys(services), function(key) { return services[key]; });
+  }
+
+  function buildStopFunction(items, thingToDo) {
+
+    return function(cb) {
+
+      function onNextItem(item, callback) {
+        item[thingToDo](function(err) {
+          callback(err);    
+        });
+      }
+
+      function done(err) {
+        cb(err);
+      }
+
+      async.eachSeries(items, onNextItem, done);
+    };
+  }
+
   function stopAllServices(cb) {
     logger.info('Stopping all services');
-    _.forOwn(containers, function(systemId, key) {
-      _.forOwn(systemId, function(container, key) {
-        if (container.release) {
-          container.release(function(err) {
-            cb(err);
-          });
-        }
+    var releaseAll = buildStopFunction(toRelease(), 'release');
+    var closeAll = buildStopFunction(toClose(), 'close');
+
+    releaseAll(function(err) {
+      closeAll(function(err) {
+        cb(err);
       });
     });
   }

--- a/lib/containers.js
+++ b/lib/containers.js
@@ -204,9 +204,23 @@ module.exports = function(loadConfig, logger, sr) {
     });
   }
 
+  function stopAllServices(cb) {
+    logger.info('Stopping all services');
+    _.forOwn(containers, function(systemId, key) {
+      _.forOwn(systemId, function(container, key) {
+        if (container.release) {
+          container.release(function(err) {
+            cb(err);
+          });
+        }
+      });
+    });
+  }
+
   return {
     getHandler: getHandler,
     listTypes: listTypes,
-    startAllServices: startAllServices
+    startAllServices: startAllServices,
+    stopAllServices: stopAllServices
   };
 };

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -101,7 +101,10 @@ module.exports = function(config, cb) {
 
   function stop() {
     logger.info('stopping operations');
-    _srv.stop();
+    _containers.stopAllServices(function(err) {
+      logger.error(err);
+    });
+    process.exit();
   }
 
   _sr.boot(function(err) {

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -102,9 +102,9 @@ module.exports = function(config, cb) {
   function stop() {
     logger.info('stopping operations');
     _containers.stopAllServices(function(err) {
-      logger.error(err);
+      if (err) { logger.error(err) process.exit(1); }
+      process.exit(0);
     });
-    process.exit();
   }
 
   _sr.boot(function(err) {

--- a/lib/kernel.js
+++ b/lib/kernel.js
@@ -102,7 +102,7 @@ module.exports = function(config, cb) {
   function stop() {
     logger.info('stopping operations');
     _containers.stopAllServices(function(err) {
-      if (err) { logger.error(err) process.exit(1); }
+      if (err) { logger.error(err); process.exit(1); }
       process.exit(0);
     });
   }


### PR DESCRIPTION
@mcollina This is what I have so far. I think it's rough around the edges. As per our discussion last week there are a number of things to be done. 

 - [ ] Writing pid files for process-containers in case nscale is killed with SIGKILL (So we can try and detect and possibly kill off rogue processes);
 - [ ] Write a stop function for the nscale-protocol so the server is stopped properly
 - [x] determine why the chokidar-child process stays alive

If there's anything I've missed here please add them below :)