### PR TITLE
Added support for the checkoutDir in the container definition.

### DIFF
--- a/lib/synchrotron.js
+++ b/lib/synchrotron.js
@@ -19,6 +19,7 @@ var fs = require('fs');
 var executor = require('nscale-util').executor();
 var sshCheck = require('nscale-util').sshcheck();
 var ku = require('./kutils');
+var p = require('path');
 
 
 
@@ -37,19 +38,21 @@ module.exports = function(loadConfig) {
       var uh = ku.parseGitUrl(containerDef.specific.repositoryUrl, options);
       var updateCmd;
       var checkoutCmd = 'git checkout ' + uh.branch;
-      var path = system.repoPath + '/workspace';
       var doSync = true;
+      var checkoutDir = containerDef.specific.checkoutDir || uh.repo;
+      var workspacePath = p.join(system.repoPath, 'workspace');
+      var checkoutPath = p.join(workspacePath, checkoutDir);
+      var updatePath;
 
       if (options.hasOwnProperty('pullOnCompile')) {
         doSync = options.pullOnCompile;
       }
 
       function execute() {
-        executor.exec('live', updateCmd, path, out, function(err) {
+        executor.exec('live', updateCmd, updatePath, out, function(err) {
           if (err) { return cb(err); }
 
-          path = system.repoPath + '/workspace/' + uh.repo;
-          executor.exec('live', checkoutCmd, path, out, function(err) {
+          executor.exec('live', checkoutCmd, checkoutPath, out, function(err) {
             cb(err);
           });
         });
@@ -57,18 +60,19 @@ module.exports = function(loadConfig) {
 
       out.stdout('--> synchronizing ' + containerDef.id, 'info');
 
-      if (fs.existsSync(path + '/' + uh.repo)) {
+      if (fs.existsSync(checkoutPath)) {
         updateCmd = 'git fetch';
-        path += '/' + uh.repo;
+        updatePath = checkoutPath;
         checkoutCmd += '; git pull origin ' + uh.branch;
       }
       else {
-        updateCmd = 'git clone ' + uh.cloneUrl;
+        updatePath = system.repoPath;
+        updateCmd = 'git clone ' + uh.cloneUrl + ' ' + p.join('workspace', checkoutDir);
         doSync = true;
       }
 
       if (doSync) {
-        wrench.mkdirSyncRecursive(path, 511);
+        wrench.mkdirSyncRecursive(workspacePath, 511);
         if (uh.type === 'git') {
           sshCheck.check(uh.host, uh.user, options.sshKeyPath, out, function(err) {
             if (err) { return cb(err); }


### PR DESCRIPTION
So by having a a definition like:

```
exports.doc = {
  type: 'docker',
  override: {
    process: {
      type: 'process'
    }
  },
  specific: {
    repositoryUrl: 'https://github.com/nearform/sudc-doc.git',
    processBuild: 'npm install',
    checkoutDir: 'doc',
    execute: {
      args: '-p 9002:9002 -d',
      process: 'srv/doc-srv.js'
    }
  }
};
```

The project will be checkout at in `workspace/doc`.

@rjrodger @pelger is this ok?